### PR TITLE
Add change grouping with optional notes

### DIFF
--- a/change-grouping-demo.md
+++ b/change-grouping-demo.md
@@ -1,0 +1,234 @@
+# Change Grouping with Notes
+
+*2026-02-08T13:41:35Z*
+
+sqlite-history-json now supports grouping related changes together and attaching notes to those groups. This is useful for tagging batch operations like imports, migrations, or multi-step updates so you can later understand *why* a set of changes were made, not just *what* changed.
+
+The mechanism uses a shared `_history_json` table with a `current` sentinel row. During a `change_group()` context, triggers automatically pick up the active group id via a subquery. Outside the context, audit rows have `group = NULL`.
+
+## Setup
+
+Create a database, a table, and enable tracking.
+
+```python
+
+import sqlite3
+from sqlite_history_json import enable_tracking, get_history, change_group
+
+conn = sqlite3.connect(':memory:')
+conn.execute('''CREATE TABLE items (
+    id INTEGER PRIMARY KEY, name TEXT, price FLOAT, quantity INTEGER
+)''')
+enable_tracking(conn, 'items')
+
+print('Tables created:')
+for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"):
+    print(f'  {row[0]}')
+
+```
+
+```output
+Tables created:
+  _history_json
+  _history_json_items
+  items
+```
+
+Both the audit table `_history_json_items` and the shared groups table `_history_json` are created.
+
+## Changes without a group
+
+Regular changes have `group = NULL` in the audit log.
+
+```python
+
+import sqlite3
+from sqlite_history_json import enable_tracking, get_history, change_group
+
+conn = sqlite3.connect(':memory:')
+conn.execute('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, price FLOAT, quantity INTEGER)')
+enable_tracking(conn, 'items')
+
+conn.execute("INSERT INTO items VALUES (1, 'Widget', 9.99, 100)")
+
+for e in get_history(conn, 'items'):
+    print(f'op={e["operation"]:6s}  group={e["group"]}  note={e["group_note"]}  vals={e["updated_values"]}')
+
+```
+
+```output
+op=insert  group=None  note=None  vals={'name': 'Widget', 'price': 9.99, 'quantity': 100}
+```
+
+## Grouping changes with a note
+
+`change_group()` is a context manager. Everything inside the block shares the same group id.
+
+```python
+
+import sqlite3
+from sqlite_history_json import enable_tracking, get_history, change_group
+
+conn = sqlite3.connect(':memory:')
+conn.execute('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, price FLOAT, quantity INTEGER)')
+enable_tracking(conn, 'items')
+
+with change_group(conn, note='bulk import from warehouse CSV') as group_id:
+    conn.execute("INSERT INTO items VALUES (1, 'Widget', 9.99, 100)")
+    conn.execute("INSERT INTO items VALUES (2, 'Gadget', 24.99, 50)")
+    conn.execute("UPDATE items SET price = 12.99 WHERE id = 1")
+
+print(f'Group ID: {group_id}')
+print()
+for e in get_history(conn, 'items'):
+    print(f'id={e["id"]}  op={e["operation"]:6s}  group={e["group"]}  note={e["group_note"]!r}')
+
+```
+
+```output
+Group ID: 1
+
+id=3  op=update  group=1  note='bulk import from warehouse CSV'
+id=2  op=insert  group=1  note='bulk import from warehouse CSV'
+id=1  op=insert  group=1  note='bulk import from warehouse CSV'
+```
+
+All three audit entries share group 1 and the note.
+
+## Multiple groups stay distinct
+
+Each `change_group()` block gets its own id. Ungrouped changes in between have `group=None`.
+
+```python
+
+import sqlite3
+from sqlite_history_json import enable_tracking, get_history, change_group
+
+conn = sqlite3.connect(':memory:')
+conn.execute('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, price FLOAT, quantity INTEGER)')
+enable_tracking(conn, 'items')
+
+with change_group(conn, note='initial stock'):
+    conn.execute("INSERT INTO items VALUES (1, 'Widget', 9.99, 100)")
+
+conn.execute("UPDATE items SET price = 7.99 WHERE id = 1")  # ungrouped
+
+with change_group(conn, note='holiday sale pricing'):
+    conn.execute("UPDATE items SET price = 4.99 WHERE id = 1")
+    conn.execute("UPDATE items SET quantity = 200 WHERE id = 1")
+
+for e in get_history(conn, 'items'):
+    print(f'id={e["id"]}  op={e["operation"]:6s}  group={str(e["group"]):>4s}  note={e["group_note"]}')
+
+```
+
+```output
+id=4  op=update  group=   2  note=holiday sale pricing
+id=3  op=update  group=   2  note=holiday sale pricing
+id=2  op=update  group=None  note=None
+id=1  op=insert  group=   1  note=initial stock
+```
+
+## Cross-table grouping
+
+A single `change_group()` block groups changes across all tracked tables.
+
+```python
+
+import sqlite3
+from sqlite_history_json import enable_tracking, get_history, change_group
+
+conn = sqlite3.connect(':memory:')
+conn.execute('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)')
+conn.execute('CREATE TABLE orders (id INTEGER PRIMARY KEY, item_id INTEGER)')
+enable_tracking(conn, 'items')
+enable_tracking(conn, 'orders')
+
+with change_group(conn, note='new product launch') as group_id:
+    conn.execute("INSERT INTO items VALUES (1, 'SuperWidget')")
+    conn.execute("INSERT INTO orders VALUES (1, 1)")
+
+for table in ['items', 'orders']:
+    entries = get_history(conn, table)
+    for e in entries:
+        print(f'{table:6s}  op={e["operation"]:6s}  group={e["group"]}  note={e["group_note"]!r}')
+
+```
+
+```output
+items   op=insert  group=1  note='new product launch'
+orders  op=insert  group=1  note='new product launch'
+```
+
+## The trigger SQL
+
+Here is the actual INSERT trigger SQL generated for the `items` table. The key addition is the subquery at the end that looks up the active group:
+
+```python
+
+import sqlite3
+from sqlite_history_json import enable_tracking
+
+conn = sqlite3.connect(':memory:')
+conn.execute('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, price FLOAT)')
+enable_tracking(conn, 'items')
+
+row = conn.execute(
+    "SELECT sql FROM sqlite_master WHERE type='trigger' AND name='_history_json_items_insert'"
+).fetchone()
+print(row[0])
+
+```
+
+```output
+CREATE TRIGGER [_history_json_items_insert]
+after insert on [items]
+begin
+    insert into [_history_json_items] (timestamp, operation, [pk_id], updated_values, [group])
+    values (
+        strftime('%Y-%m-%d %H:%M:%f', 'now'),
+        'insert',
+        NEW.[id],
+        json_object('name', case when NEW.[name] is null then json_object('null', 1) else NEW.[name] end, 'price', case when NEW.[price] is null then json_object('null', 1) else NEW.[price] end),
+        (select id from [_history_json] where current = 1)
+    );
+end
+```
+
+The groups table and audit table schemas:
+
+```python
+
+import sqlite3
+from sqlite_history_json import enable_tracking
+
+conn = sqlite3.connect(':memory:')
+conn.execute('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)')
+enable_tracking(conn, 'items')
+
+for name in ['_history_json', '_history_json_items']:
+    row = conn.execute("SELECT sql FROM sqlite_master WHERE type='table' AND name=?", [name]).fetchone()
+    print(row[0])
+    print()
+
+```
+
+```output
+CREATE TABLE [_history_json] (
+    id integer primary key,
+    note text,
+    current integer
+)
+
+CREATE TABLE [_history_json_items] (
+    id integer primary key,
+    timestamp text,
+    operation text,
+    [pk_id] INTEGER,
+    updated_values text,
+    [group] integer references [_history_json](id)
+)
+
+```
+
+The `[group]` column on the audit table references `_history_json(id)`. The `current` column on the groups table is indexed and acts as the sentinel: set to 1 during an active `change_group()` block, NULL otherwise.

--- a/sqlite_history_json/__init__.py
+++ b/sqlite_history_json/__init__.py
@@ -1,6 +1,7 @@
 """SQLite table history tracking using a JSON audit log."""
 
 from .core import (
+    change_group,
     disable_tracking,
     enable_tracking,
     get_history,
@@ -11,6 +12,7 @@ from .core import (
 )
 
 __all__ = [
+    "change_group",
     "enable_tracking",
     "disable_tracking",
     "populate",

--- a/sqlite_history_json/core.py
+++ b/sqlite_history_json/core.py
@@ -147,7 +147,7 @@ def _build_insert_trigger_sql(
 
     json_obj = f"json_object({', '.join(json_args)})" if json_args else "'{{}}'"
 
-    group_subquery = f"(select id from [{_GROUPS_TABLE}] where current = 1 order by id desc limit 1)"
+    group_subquery = f"(select id from [{_GROUPS_TABLE}] where current = 1)"
 
     return f"""create trigger if not exists [{audit_name}_insert]
 after insert on [{table_name}]
@@ -210,7 +210,7 @@ def _build_update_trigger_sql(
 
         json_expr = expr
 
-    group_subquery = f"(select id from [{_GROUPS_TABLE}] where current = 1 order by id desc limit 1)"
+    group_subquery = f"(select id from [{_GROUPS_TABLE}] where current = 1)"
 
     return f"""create trigger if not exists [{audit_name}_update]
 after update on [{table_name}]
@@ -237,7 +237,7 @@ def _build_delete_trigger_sql(
     )
     pk_old_refs = ", ".join(f"OLD.[{c['name']}]" for c in pk_cols)
 
-    group_subquery = f"(select id from [{_GROUPS_TABLE}] where current = 1 order by id desc limit 1)"
+    group_subquery = f"(select id from [{_GROUPS_TABLE}] where current = 1)"
 
     return f"""create trigger if not exists [{audit_name}_delete]
 after delete on [{table_name}]
@@ -421,7 +421,7 @@ def populate(conn: sqlite3.Connection, table_name: str) -> None:
 
         json_str = json.dumps(json_dict)
 
-        group_subquery = f"(select id from [{_GROUPS_TABLE}] where current = 1 order by id desc limit 1)"
+        group_subquery = f"(select id from [{_GROUPS_TABLE}] where current = 1)"
         conn.execute(
             f"insert into [{audit_name}] (timestamp, operation, {pk_insert_cols}, updated_values, [group]) "
             f"values (strftime('%Y-%m-%d %H:%M:%f', 'now'), 'insert', {pk_insert_params}, ?, "

--- a/tests/test_sqlite_history_json.py
+++ b/tests/test_sqlite_history_json.py
@@ -1191,3 +1191,14 @@ class TestChangeGrouping:
         assert len(rows) == 3
         for row in rows:
             assert row["group"] == group_id
+
+    def test_only_one_current_row_allowed(self, simple_table):
+        """A unique partial index should prevent multiple current=1 rows."""
+        enable_tracking(simple_table, "items")
+        simple_table.execute(
+            "INSERT INTO _history_json (note, current) VALUES ('first', 1)"
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            simple_table.execute(
+                "INSERT INTO _history_json (note, current) VALUES ('second', 1)"
+            )

--- a/tests/test_sqlite_history_json.py
+++ b/tests/test_sqlite_history_json.py
@@ -5,7 +5,15 @@ import sqlite3
 
 import pytest
 
-from sqlite_history_json import disable_tracking, enable_tracking, populate, restore
+from sqlite_history_json import (
+    change_group,
+    disable_tracking,
+    enable_tracking,
+    get_history,
+    get_row_history,
+    populate,
+    restore,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -982,3 +990,204 @@ class TestEdgeCases:
         ).fetchone()
         assert dict(row)["name"] == "NewWidget"
         assert dict(row)["price"] == 5.99
+
+
+# ---------------------------------------------------------------------------
+# Tests: change grouping
+# ---------------------------------------------------------------------------
+
+
+class TestChangeGrouping:
+    def test_groups_table_created_by_enable_tracking(self, simple_table):
+        """enable_tracking should create the _history_json groups table."""
+        enable_tracking(simple_table, "items")
+        assert table_exists(simple_table, "_history_json")
+
+    def test_audit_table_has_group_column(self, simple_table):
+        """The audit table should have a [group] column."""
+        enable_tracking(simple_table, "items")
+        info = simple_table.execute(
+            "PRAGMA table_info(_history_json_items)"
+        ).fetchall()
+        col_names = [r[1] for r in info]
+        assert "group" in col_names
+
+    def test_group_is_null_without_context_manager(self, simple_table):
+        """Without change_group, audit rows should have group = NULL."""
+        enable_tracking(simple_table, "items")
+        simple_table.execute(
+            "INSERT INTO items (id, name, price, quantity) VALUES (1, 'Widget', 9.99, 100)"
+        )
+        rows = get_audit_rows(simple_table, "items")
+        assert rows[0]["group"] is None
+
+    def test_change_group_assigns_same_group(self, simple_table):
+        """All changes within change_group should share the same group id."""
+        enable_tracking(simple_table, "items")
+        with change_group(simple_table) as group_id:
+            simple_table.execute(
+                "INSERT INTO items (id, name, price, quantity) VALUES (1, 'Widget', 9.99, 100)"
+            )
+            simple_table.execute(
+                "INSERT INTO items (id, name, price, quantity) VALUES (2, 'Gadget', 24.99, 50)"
+            )
+            simple_table.execute("UPDATE items SET name = 'Gizmo' WHERE id = 1")
+        rows = get_audit_rows(simple_table, "items")
+        assert len(rows) == 3
+        for row in rows:
+            assert row["group"] == group_id
+
+    def test_change_group_with_note(self, simple_table):
+        """A note can be attached to a change group."""
+        enable_tracking(simple_table, "items")
+        with change_group(simple_table, note="bulk import"):
+            simple_table.execute(
+                "INSERT INTO items (id, name, price, quantity) VALUES (1, 'Widget', 9.99, 100)"
+            )
+        # Check the groups table for the note
+        group_row = simple_table.execute(
+            "SELECT * FROM _history_json ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        assert dict(group_row)["note"] == "bulk import"
+
+    def test_change_group_clears_current_after_exit(self, simple_table):
+        """After the context manager exits, current should be NULL."""
+        enable_tracking(simple_table, "items")
+        with change_group(simple_table, note="test"):
+            simple_table.execute(
+                "INSERT INTO items (id, name, price, quantity) VALUES (1, 'Widget', 9.99, 100)"
+            )
+        # No row should have current = 1
+        current_rows = simple_table.execute(
+            "SELECT * FROM _history_json WHERE current = 1"
+        ).fetchall()
+        assert len(current_rows) == 0
+
+    def test_changes_after_group_have_null_group(self, simple_table):
+        """Changes made after the context manager exits should have group = NULL."""
+        enable_tracking(simple_table, "items")
+        with change_group(simple_table):
+            simple_table.execute(
+                "INSERT INTO items (id, name, price, quantity) VALUES (1, 'Widget', 9.99, 100)"
+            )
+        # This insert is outside the group
+        simple_table.execute(
+            "INSERT INTO items (id, name, price, quantity) VALUES (2, 'Gadget', 24.99, 50)"
+        )
+        rows = get_audit_rows(simple_table, "items")
+        assert rows[0]["group"] is not None  # inside group
+        assert rows[1]["group"] is None  # outside group
+
+    def test_multiple_groups_are_distinct(self, simple_table):
+        """Two separate change_group blocks should produce different group ids."""
+        enable_tracking(simple_table, "items")
+        with change_group(simple_table, note="first") as gid1:
+            simple_table.execute(
+                "INSERT INTO items (id, name, price, quantity) VALUES (1, 'A', 1.0, 1)"
+            )
+        with change_group(simple_table, note="second") as gid2:
+            simple_table.execute(
+                "INSERT INTO items (id, name, price, quantity) VALUES (2, 'B', 2.0, 2)"
+            )
+        assert gid1 != gid2
+        rows = get_audit_rows(simple_table, "items")
+        assert rows[0]["group"] == gid1
+        assert rows[1]["group"] == gid2
+
+    def test_change_group_with_delete(self, simple_table):
+        """Delete operations should also be grouped."""
+        enable_tracking(simple_table, "items")
+        simple_table.execute(
+            "INSERT INTO items (id, name, price, quantity) VALUES (1, 'Widget', 9.99, 100)"
+        )
+        with change_group(simple_table, note="cleanup") as group_id:
+            simple_table.execute("DELETE FROM items WHERE id = 1")
+        rows = get_audit_rows(simple_table, "items")
+        assert rows[0]["group"] is None  # the insert, outside group
+        assert rows[1]["group"] == group_id  # the delete, inside group
+
+    def test_change_group_yields_group_id(self, simple_table):
+        """The context manager should yield an integer group id."""
+        enable_tracking(simple_table, "items")
+        with change_group(simple_table) as group_id:
+            assert isinstance(group_id, int)
+
+    def test_change_group_note_can_be_updated(self, simple_table):
+        """The note on the current group can be updated during the block."""
+        enable_tracking(simple_table, "items")
+        with change_group(simple_table, note="initial") as group_id:
+            simple_table.execute(
+                "INSERT INTO items (id, name, price, quantity) VALUES (1, 'Widget', 9.99, 100)"
+            )
+            # Update the note mid-transaction
+            simple_table.execute(
+                "UPDATE _history_json SET note = 'updated' WHERE id = ?",
+                [group_id],
+            )
+        group_row = simple_table.execute(
+            "SELECT note FROM _history_json WHERE id = ?", [group_id]
+        ).fetchone()
+        assert dict(group_row)["note"] == "updated"
+
+    def test_get_history_includes_group_info(self, simple_table):
+        """get_history should include group and group_note in results."""
+        enable_tracking(simple_table, "items")
+        with change_group(simple_table, note="batch"):
+            simple_table.execute(
+                "INSERT INTO items (id, name, price, quantity) VALUES (1, 'Widget', 9.99, 100)"
+            )
+        entries = get_history(simple_table, "items")
+        assert len(entries) == 1
+        assert "group" in entries[0]
+        assert entries[0]["group"] is not None
+        assert "group_note" in entries[0]
+        assert entries[0]["group_note"] == "batch"
+
+    def test_get_history_null_group(self, simple_table):
+        """get_history should return None for group/group_note when no group."""
+        enable_tracking(simple_table, "items")
+        simple_table.execute(
+            "INSERT INTO items (id, name, price, quantity) VALUES (1, 'Widget', 9.99, 100)"
+        )
+        entries = get_history(simple_table, "items")
+        assert entries[0]["group"] is None
+        assert entries[0]["group_note"] is None
+
+    def test_get_row_history_includes_group_info(self, simple_table):
+        """get_row_history should include group info."""
+        enable_tracking(simple_table, "items")
+        with change_group(simple_table, note="row-note"):
+            simple_table.execute(
+                "INSERT INTO items (id, name, price, quantity) VALUES (1, 'Widget', 9.99, 100)"
+            )
+        entries = get_row_history(simple_table, "items", {"id": 1})
+        assert entries[0]["group_note"] == "row-note"
+
+    def test_change_group_across_multiple_tables(self, conn):
+        """A single change_group should group changes across different tracked tables."""
+        conn.execute(
+            "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE orders (id INTEGER PRIMARY KEY, item_id INTEGER)"
+        )
+        enable_tracking(conn, "items")
+        enable_tracking(conn, "orders")
+        with change_group(conn, note="cross-table") as group_id:
+            conn.execute("INSERT INTO items (id, name) VALUES (1, 'Widget')")
+            conn.execute("INSERT INTO orders (id, item_id) VALUES (1, 1)")
+        item_rows = get_audit_rows(conn, "items")
+        order_rows = get_audit_rows(conn, "orders")
+        assert item_rows[0]["group"] == group_id
+        assert order_rows[0]["group"] == group_id
+
+    def test_populate_respects_change_group(self, simple_table_with_data):
+        """populate() called within change_group should tag entries with that group."""
+        conn = simple_table_with_data
+        enable_tracking(conn, "items", populate_table=False)
+        with change_group(conn, note="initial snapshot") as group_id:
+            populate(conn, "items")
+        rows = get_audit_rows(conn, "items")
+        assert len(rows) == 3
+        for row in rows:
+            assert row["group"] == group_id


### PR DESCRIPTION
> Experiment with a mechanism for grouping changes in the same reaction and adding optional notes to those groups
> 
> Here's my design - tell me what you think
> 
> The _history_json_X tables gain a new integer column called group - a foreign key against a new _history_json (no suffix) table
> 
> _history_json has three columns: id int primary key, note text, current integer (indexed)
> 
> current should be null on all rows. Only during a transaction with write activity is there a row with current set to 1
> 
> Any time a trigger fires during a transaction it checks to see if there is a row with current = 1 - if there is not then it inserts a new row - which he's an auto primary key - with current = 1 on it.
> 
> All rows inserted into the history tracking tables can then use that current  = 1 row in their group column.
> 
> During the transaction anything can write to the note column in that current row. Additionally at the start of the transaction before any triggers fire someone can create that current row and populate it with a note. In this way the library user can add a note that gets recorded during that transaction.
> 
> Here's the bit I haven't figured out yet: at the end of the transaction it's crucial to set current back to null again, but can I rig up a trigger that fires only at the end of the transaction after the iteration have fired? If not this whole design may be flawed.

(It fixed the design flaw: "Your design was fundamentally sound. The one change I made: triggers don’t auto-create groups. Instead they just look up (SELECT id FROM [_history_json] WHERE current = 1) — which returns NULL when no group is active. This sidesteps the “how to clean up at transaction end” problem entirely".)

Adds a mechanism for grouping related audit log entries together and
attaching an optional note to describe the batch. Uses a shared
`_history_json` groups table with a `current` sentinel column that
triggers look up via subquery.

- New `_history_json` table: id, note, current (indexed)
- Audit tables gain `[group]` column (FK to groups table)
- All three triggers (INSERT/UPDATE/DELETE) include group subquery
- `change_group(conn, note=None)` context manager for Python API
- `get_history()` and `get_row_history()` return group/group_note
- `populate()` respects active change group
- 16 new tests covering all grouping scenarios
- Updated README with schema docs, usage examples, API reference
- Showboat demo document

https://claude.ai/code/session_0173nuhzUEdDinKYkVybuy3h