### PR TITLE
Add upgrade module for migrating older databases to current schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,30 @@ python -m sqlite_history_json row-state-sql mydb.db items
 
 The output is a ready-to-execute SQL query using a recursive CTE and `json_patch()`. You can pipe it to other tools or use it directly with named parameters (`:pk` and `:target_id` for single-PK tables, `:pk_1`, `:pk_2`, ... for compound PKs).
 
+## Upgrading older databases
+
+Databases created with version 0.3a0 or earlier do not have the `[group]` column or the `_history_json` groups table. A built-in upgrade script detects and applies the necessary schema changes.
+
+Preview what would be changed:
+
+```bash
+python -m sqlite_history_json.upgrade mydb.db --dry-run
+```
+
+Apply the upgrade:
+
+```bash
+python -m sqlite_history_json.upgrade mydb.db
+```
+
+This will:
+
+1. Create the `_history_json` groups table if it doesn't exist
+2. Add the `[group]` column to any audit tables missing it
+3. Drop and recreate triggers so they populate the new column
+
+Existing audit data is preserved — pre-upgrade rows get `group = NULL`. The upgrade is idempotent: running it on an already-current database does nothing.
+
 ## Development
 
 ```bash

--- a/demos/upgrade_demo.md
+++ b/demos/upgrade_demo.md
@@ -1,0 +1,357 @@
+# Upgrading older sqlite-history-json databases
+
+*2026-02-09T00:41:08Z*
+
+Databases created with sqlite-history-json 0.3a0 or earlier use an older audit table schema that doesn't include the `[group]` column for change grouping. This demo shows how to upgrade them.
+
+First, let's create a database and enable tracking using the published 0.3a0 release (which predates change-grouping support).
+
+```bash
+uv run --no-project --with "sqlite-history-json==0.3a0" python -c "
+import sqlite3
+from sqlite_history_json import enable_tracking
+conn = sqlite3.connect(\"demo.db\")
+conn.execute(\"CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, price FLOAT, quantity INTEGER)\")
+enable_tracking(conn, \"items\")
+conn.commit()
+conn.close()
+print(\"Database created with tracking enabled.\")
+"
+```
+
+```output
+Database created with tracking enabled.
+```
+
+Now let's make some changes to generate audit history.
+
+```bash
+uv run --no-project --with "sqlite-history-json==0.3a0" python -c "
+import sqlite3
+conn = sqlite3.connect(\"demo.db\")
+conn.execute(\"INSERT INTO items VALUES (1, 'Widget', 9.99, 100)\")
+conn.execute(\"INSERT INTO items VALUES (2, 'Gadget', 24.99, 50)\")
+conn.execute(\"UPDATE items SET price = 12.99 WHERE id = 1\")
+conn.execute(\"DELETE FROM items WHERE id = 2\")
+conn.commit()
+conn.close()
+print(\"Changes applied.\")
+"
+```
+
+```output
+Changes applied.
+```
+
+Let's look at the audit history. Note there are no `group` or `group_note` fields.
+
+```bash
+uv run --no-project --with "sqlite-history-json==0.3a0" python -c "
+import sqlite3, json
+from sqlite_history_json import get_history
+conn = sqlite3.connect(\"demo.db\")
+conn.row_factory = sqlite3.Row
+entries = get_history(conn, \"items\")
+print(json.dumps(entries, indent=2))
+conn.close()
+"
+```
+
+```output
+[
+  {
+    "id": 4,
+    "timestamp": "2026-02-09 00:41:49.233",
+    "operation": "delete",
+    "pk": {
+      "id": 2
+    },
+    "updated_values": null
+  },
+  {
+    "id": 3,
+    "timestamp": "2026-02-09 00:41:49.233",
+    "operation": "update",
+    "pk": {
+      "id": 1
+    },
+    "updated_values": {
+      "price": 12.99
+    }
+  },
+  {
+    "id": 2,
+    "timestamp": "2026-02-09 00:41:49.233",
+    "operation": "insert",
+    "pk": {
+      "id": 2
+    },
+    "updated_values": {
+      "name": "Gadget",
+      "price": 24.99,
+      "quantity": 50
+    }
+  },
+  {
+    "id": 1,
+    "timestamp": "2026-02-09 00:41:49.233",
+    "operation": "insert",
+    "pk": {
+      "id": 1
+    },
+    "updated_values": {
+      "name": "Widget",
+      "price": 9.99,
+      "quantity": 100
+    }
+  }
+]
+```
+
+And here's the audit table schema — no `[group]` column, and no `_history_json` groups table.
+
+```bash
+uv run --no-project --with "sqlite-history-json==0.3a0" python -c "
+import sqlite3
+conn = sqlite3.connect(\"demo.db\")
+cols = [r[1] for r in conn.execute(\"PRAGMA table_info(_history_json_items)\").fetchall()]
+print(\"Audit table columns:\", cols)
+tables = [r[0] for r in conn.execute(\"SELECT name FROM sqlite_master WHERE type='table' ORDER BY name\").fetchall()]
+print(\"All tables:\", tables)
+conn.close()
+"
+```
+
+```output
+Audit table columns: ['id', 'timestamp', 'operation', 'pk_id', 'updated_values']
+All tables: ['_history_json_items', 'items']
+```
+
+Now let's run the upgrade script. First with `--dry-run` to see what it would do.
+
+```bash
+PYTHONPATH=/home/user/sqlite-history-json python -m sqlite_history_json.upgrade demo.db --dry-run
+```
+
+```output
+Would upgrade _history_json_items: add [group] column, recreate triggers
+```
+
+Looks good. Let's apply the upgrade for real.
+
+```bash
+PYTHONPATH=/home/user/sqlite-history-json python -m sqlite_history_json.upgrade demo.db
+```
+
+```output
+Upgraded _history_json_items: added [group] column, recreated triggers
+```
+
+Let's verify the schema has been updated. The audit table now has a `[group]` column, and the `_history_json` groups table exists.
+
+```bash
+PYTHONPATH=/home/user/sqlite-history-json python -c "
+import sqlite3
+conn = sqlite3.connect(\"demo.db\")
+cols = [r[1] for r in conn.execute(\"PRAGMA table_info(_history_json_items)\").fetchall()]
+print(\"Audit table columns:\", cols)
+tables = [r[0] for r in conn.execute(\"SELECT name FROM sqlite_master WHERE type='table' ORDER BY name\").fetchall()]
+print(\"All tables:\", tables)
+conn.close()
+"
+```
+
+```output
+Audit table columns: ['id', 'timestamp', 'operation', 'pk_id', 'updated_values', 'group']
+All tables: ['_history_json', '_history_json_items', 'items']
+```
+
+Existing audit data is preserved — the old rows now have `group = NULL`.
+
+```bash
+PYTHONPATH=/home/user/sqlite-history-json python -c "
+import sqlite3, json
+from sqlite_history_json import get_history
+conn = sqlite3.connect(\"demo.db\")
+conn.row_factory = sqlite3.Row
+entries = get_history(conn, \"items\")
+print(json.dumps(entries, indent=2))
+conn.close()
+"
+```
+
+```output
+[
+  {
+    "id": 4,
+    "timestamp": "2026-02-09 00:41:49.233",
+    "operation": "delete",
+    "pk": {
+      "id": 2
+    },
+    "updated_values": null,
+    "group": null,
+    "group_note": null
+  },
+  {
+    "id": 3,
+    "timestamp": "2026-02-09 00:41:49.233",
+    "operation": "update",
+    "pk": {
+      "id": 1
+    },
+    "updated_values": {
+      "price": 12.99
+    },
+    "group": null,
+    "group_note": null
+  },
+  {
+    "id": 2,
+    "timestamp": "2026-02-09 00:41:49.233",
+    "operation": "insert",
+    "pk": {
+      "id": 2
+    },
+    "updated_values": {
+      "name": "Gadget",
+      "price": 24.99,
+      "quantity": 50
+    },
+    "group": null,
+    "group_note": null
+  },
+  {
+    "id": 1,
+    "timestamp": "2026-02-09 00:41:49.233",
+    "operation": "insert",
+    "pk": {
+      "id": 1
+    },
+    "updated_values": {
+      "name": "Widget",
+      "price": 9.99,
+      "quantity": 100
+    },
+    "group": null,
+    "group_note": null
+  }
+]
+```
+
+Now we can use `change_group()` to group new changes together with a note.
+
+```bash
+PYTHONPATH=/home/user/sqlite-history-json python -c "
+import sqlite3, json
+from sqlite_history_json import change_group, get_history
+conn = sqlite3.connect(\"demo.db\")
+conn.row_factory = sqlite3.Row
+with change_group(conn, note=\"price adjustment\"):
+    conn.execute(\"UPDATE items SET price = 14.99 WHERE id = 1\")
+    conn.execute(\"INSERT INTO items VALUES (3, 'Doohickey', 4.99, 200)\")
+conn.commit()
+entries = get_history(conn, \"items\")
+print(json.dumps(entries, indent=2))
+conn.close()
+"
+```
+
+```output
+[
+  {
+    "id": 6,
+    "timestamp": "2026-02-09 00:43:47.193",
+    "operation": "insert",
+    "pk": {
+      "id": 3
+    },
+    "updated_values": {
+      "name": "Doohickey",
+      "price": 4.99,
+      "quantity": 200
+    },
+    "group": 1,
+    "group_note": "price adjustment"
+  },
+  {
+    "id": 5,
+    "timestamp": "2026-02-09 00:43:47.193",
+    "operation": "update",
+    "pk": {
+      "id": 1
+    },
+    "updated_values": {
+      "price": 14.99
+    },
+    "group": 1,
+    "group_note": "price adjustment"
+  },
+  {
+    "id": 4,
+    "timestamp": "2026-02-09 00:41:49.233",
+    "operation": "delete",
+    "pk": {
+      "id": 2
+    },
+    "updated_values": null,
+    "group": null,
+    "group_note": null
+  },
+  {
+    "id": 3,
+    "timestamp": "2026-02-09 00:41:49.233",
+    "operation": "update",
+    "pk": {
+      "id": 1
+    },
+    "updated_values": {
+      "price": 12.99
+    },
+    "group": null,
+    "group_note": null
+  },
+  {
+    "id": 2,
+    "timestamp": "2026-02-09 00:41:49.233",
+    "operation": "insert",
+    "pk": {
+      "id": 2
+    },
+    "updated_values": {
+      "name": "Gadget",
+      "price": 24.99,
+      "quantity": 50
+    },
+    "group": null,
+    "group_note": null
+  },
+  {
+    "id": 1,
+    "timestamp": "2026-02-09 00:41:49.233",
+    "operation": "insert",
+    "pk": {
+      "id": 1
+    },
+    "updated_values": {
+      "name": "Widget",
+      "price": 9.99,
+      "quantity": 100
+    },
+    "group": null,
+    "group_note": null
+  }
+]
+```
+
+The two newest entries share the same `group` ID and `group_note`, while the older pre-upgrade entries remain with `group: null`. The upgrade is complete — old history is preserved and new grouping features work.
+
+Running the upgrade again is safe — it detects nothing needs to be done.
+
+```bash
+PYTHONPATH=/home/user/sqlite-history-json python -m sqlite_history_json.upgrade demo.db
+```
+
+```output
+Nothing to upgrade.
+```

--- a/sqlite_history_json/upgrade.py
+++ b/sqlite_history_json/upgrade.py
@@ -1,0 +1,230 @@
+"""Upgrade older sqlite-history-json databases to the current schema.
+
+Run as::
+
+    python -m sqlite_history_json.upgrade database.db
+    python -m sqlite_history_json.upgrade database.db --dry-run
+
+The upgrade detects audit tables created before change-grouping support
+was added and:
+
+1. Creates the ``_history_json`` groups table (if it does not exist).
+2. Adds a ``[group]`` column to each audit table that is missing it.
+3. Drops and recreates triggers so they populate the new column.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+
+from .core import (
+    _audit_table_name,
+    _build_delete_trigger_sql,
+    _build_insert_trigger_sql,
+    _build_update_trigger_sql,
+    _ensure_groups_table,
+    _get_non_pk_columns,
+    _get_pk_columns,
+    _get_table_info,
+    _GROUPS_TABLE,
+)
+
+
+def _find_audit_tables(conn: sqlite3.Connection) -> list[str]:
+    """Return names of all audit tables (``_history_json_*``)."""
+    prefix = "_history_json_"
+    rows = conn.execute(
+        "select name from sqlite_master where type = 'table' "
+        "and name like ? escape '\\'",
+        (prefix.replace("_", "\\_", 2) + "%",),
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    """Check whether *table* already has a column named *column*."""
+    cols = conn.execute(f"pragma table_info([{table}])").fetchall()
+    return any(r[1] == column for r in cols)
+
+
+def _source_table_for(audit_name: str) -> str:
+    """Derive the source table name from an audit table name."""
+    return audit_name[len("_history_json_"):]
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    return (
+        conn.execute(
+            "select count(*) from sqlite_master where type = 'table' and name = ?",
+            (name,),
+        ).fetchone()[0]
+        > 0
+    )
+
+
+def _trigger_sql(conn: sqlite3.Connection, trigger_name: str) -> str | None:
+    """Return the SQL body of an existing trigger, or None."""
+    row = conn.execute(
+        "select sql from sqlite_master where type = 'trigger' and name = ?",
+        (trigger_name,),
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _trigger_needs_upgrade(conn: sqlite3.Connection, audit_name: str) -> bool:
+    """Return True if any trigger for *audit_name* is missing the group subquery."""
+    for suffix in ("_insert", "_update", "_delete"):
+        sql = _trigger_sql(conn, f"{audit_name}{suffix}")
+        if sql is not None and "[group]" not in sql:
+            return True
+    return False
+
+
+def detect_upgrades(conn: sqlite3.Connection) -> list[dict]:
+    """Scan the database and return a list of upgrade actions needed.
+
+    Each item is a dict with keys:
+
+    * ``audit_table`` – the audit table name
+    * ``source_table`` – the tracked source table name (or ``None``)
+    * ``needs_column`` – ``True`` if the ``[group]`` column is missing
+    * ``needs_triggers`` – ``True`` if triggers need to be recreated
+    * ``source_exists`` – ``True`` if the source table still exists
+    """
+    groups_table_exists = _table_exists(conn, _GROUPS_TABLE)
+
+    actions = []
+    for audit_name in _find_audit_tables(conn):
+        source_table = _source_table_for(audit_name)
+        source_exists = _table_exists(conn, source_table)
+        needs_column = not _has_column(conn, audit_name, "group")
+        needs_triggers = (
+            source_exists and _trigger_needs_upgrade(conn, audit_name)
+        )
+
+        if needs_column or needs_triggers:
+            actions.append(
+                {
+                    "audit_table": audit_name,
+                    "source_table": source_table,
+                    "needs_column": needs_column,
+                    "needs_triggers": needs_triggers,
+                    "source_exists": source_exists,
+                }
+            )
+
+    return actions
+
+
+def apply_upgrade(conn: sqlite3.Connection) -> list[dict]:
+    """Apply all detected upgrades and return the list of actions taken.
+
+    Returns the same structure as :func:`detect_upgrades` for the items
+    that were actually upgraded.
+    """
+    actions = detect_upgrades(conn)
+    if not actions:
+        return []
+
+    # Ensure the groups table exists first (column FK target)
+    _ensure_groups_table(conn)
+
+    for action in actions:
+        audit_name = action["audit_table"]
+        source_table = action["source_table"]
+
+        # 1. Add the [group] column if missing
+        if action["needs_column"]:
+            conn.execute(
+                f"alter table [{audit_name}] "
+                f"add column [group] integer references [{_GROUPS_TABLE}](id)"
+            )
+
+        # 2. Recreate triggers if the source table still exists
+        if action["needs_triggers"] and action["source_exists"]:
+            columns = _get_table_info(conn, source_table)
+            pk_cols = _get_pk_columns(columns)
+            non_pk_cols = _get_non_pk_columns(columns)
+
+            # Drop old triggers
+            for suffix in ("_insert", "_update", "_delete"):
+                conn.execute(
+                    f"drop trigger if exists [{audit_name}{suffix}]"
+                )
+
+            # Create new triggers (with [group] subquery)
+            conn.execute(
+                _build_insert_trigger_sql(
+                    source_table, audit_name, pk_cols, non_pk_cols
+                )
+            )
+            conn.execute(
+                _build_update_trigger_sql(
+                    source_table, audit_name, pk_cols, non_pk_cols
+                )
+            )
+            conn.execute(
+                _build_delete_trigger_sql(source_table, audit_name, pk_cols)
+            )
+
+    return actions
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="python -m sqlite_history_json.upgrade",
+        description=(
+            "Upgrade an older sqlite-history-json database to the current schema."
+        ),
+    )
+    parser.add_argument("database", help="Path to the SQLite database file.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be done without making changes.",
+    )
+    args = parser.parse_args(argv)
+
+    conn = sqlite3.connect(args.database)
+    try:
+        if args.dry_run:
+            actions = detect_upgrades(conn)
+            if not actions:
+                print("Nothing to upgrade.", file=sys.stderr)
+            else:
+                for action in actions:
+                    parts = []
+                    if action["needs_column"]:
+                        parts.append("add [group] column")
+                    if action["needs_triggers"]:
+                        parts.append("recreate triggers")
+                    print(
+                        f"Would upgrade {action['audit_table']}: "
+                        + ", ".join(parts),
+                        file=sys.stderr,
+                    )
+        else:
+            actions = apply_upgrade(conn)
+            if not actions:
+                print("Nothing to upgrade.", file=sys.stderr)
+            else:
+                conn.commit()
+                for action in actions:
+                    parts = []
+                    if action["needs_column"]:
+                        parts.append("added [group] column")
+                    if action["needs_triggers"]:
+                        parts.append("recreated triggers")
+                    print(
+                        f"Upgraded {action['audit_table']}: "
+                        + ", ".join(parts),
+                        file=sys.stderr,
+                    )
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,0 +1,609 @@
+"""Tests for the sqlite_history_json.upgrade module."""
+
+import sqlite3
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+from sqlite_history_json import (
+    change_group,
+    enable_tracking,
+    get_history,
+    get_row_history,
+)
+from sqlite_history_json.upgrade import (
+    _find_audit_tables,
+    _has_column,
+    _trigger_needs_upgrade,
+    apply_upgrade,
+    detect_upgrades,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for simulating old-style (pre-group) databases
+# ---------------------------------------------------------------------------
+
+
+def _create_old_style_tracking(conn: sqlite3.Connection, table_name: str) -> None:
+    """Set up audit table and triggers the way they looked before change-grouping.
+
+    This creates an audit table WITHOUT the [group] column and triggers
+    that do NOT populate it — matching the schema from before commit a80c34d.
+    """
+    columns = conn.execute(f"pragma table_info([{table_name}])").fetchall()
+    pk_cols = sorted(
+        [c for c in columns if c[5] > 0], key=lambda c: c[5]
+    )
+    non_pk_cols = [c for c in columns if c[5] == 0]
+
+    audit_name = f"_history_json_{table_name}"
+
+    pk_col_defs = ", ".join(f"[pk_{c[1]}] {c[2]}" for c in pk_cols)
+
+    # Old-style audit table: no [group] column
+    conn.execute(
+        f"""create table [{audit_name}] (
+    id integer primary key,
+    timestamp text,
+    operation text,
+    {pk_col_defs},
+    updated_values text
+)"""
+    )
+
+    # Old-style insert trigger: no [group]
+    audit_pk_names = ", ".join(f"[pk_{c[1]}]" for c in pk_cols)
+    pk_new_refs = ", ".join(f"NEW.[{c[1]}]" for c in pk_cols)
+    json_args = ", ".join(
+        f"'{c[1]}', case when NEW.[{c[1]}] is null "
+        f"then json_object('null', 1) else NEW.[{c[1]}] end"
+        for c in non_pk_cols
+    )
+    json_obj = f"json_object({json_args})" if json_args else "'{{}}'"
+
+    conn.execute(
+        f"""create trigger [{audit_name}_insert]
+after insert on [{table_name}]
+begin
+    insert into [{audit_name}] (timestamp, operation, {audit_pk_names}, updated_values)
+    values (
+        strftime('%Y-%m-%d %H:%M:%f', 'now'),
+        'insert',
+        {pk_new_refs},
+        {json_obj}
+    );
+end;"""
+    )
+
+    # Old-style update trigger (simplified: records all non-PK cols)
+    conn.execute(
+        f"""create trigger [{audit_name}_update]
+after update on [{table_name}]
+begin
+    insert into [{audit_name}] (timestamp, operation, {audit_pk_names}, updated_values)
+    values (
+        strftime('%Y-%m-%d %H:%M:%f', 'now'),
+        'update',
+        {pk_new_refs},
+        {json_obj}
+    );
+end;"""
+    )
+
+    # Old-style delete trigger
+    pk_old_refs = ", ".join(f"OLD.[{c[1]}]" for c in pk_cols)
+    conn.execute(
+        f"""create trigger [{audit_name}_delete]
+after delete on [{table_name}]
+begin
+    insert into [{audit_name}] (timestamp, operation, {audit_pk_names}, updated_values)
+    values (
+        strftime('%Y-%m-%d %H:%M:%f', 'now'),
+        'delete',
+        {pk_old_refs},
+        null
+    );
+end;"""
+    )
+
+    # Create indexes (same as current code)
+    conn.execute(
+        f"create index [{audit_name}_timestamp] on [{audit_name}] (timestamp)"
+    )
+    audit_pk_col_names = ", ".join(f"[pk_{c[1]}]" for c in pk_cols)
+    conn.execute(
+        f"create index [{audit_name}_pk] on [{audit_name}] ({audit_pk_col_names})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def conn():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def old_db(conn):
+    """Database with an old-style tracked table (no group column)."""
+    conn.execute(
+        "create table items ("
+        "id integer primary key, name text, price float, quantity integer)"
+    )
+    _create_old_style_tracking(conn, "items")
+    # Insert some data so there's history
+    conn.execute(
+        "insert into items (id, name, price, quantity) values (1, 'Widget', 9.99, 100)"
+    )
+    conn.execute("update items set price = 12.99 where id = 1")
+    return conn
+
+
+@pytest.fixture
+def old_db_multi(conn):
+    """Database with two old-style tracked tables."""
+    conn.execute(
+        "create table items ("
+        "id integer primary key, name text, price float)"
+    )
+    conn.execute(
+        "create table orders ("
+        "id integer primary key, item_id integer, qty integer)"
+    )
+    _create_old_style_tracking(conn, "items")
+    _create_old_style_tracking(conn, "orders")
+    conn.execute("insert into items (id, name, price) values (1, 'Widget', 9.99)")
+    conn.execute("insert into orders (id, item_id, qty) values (1, 1, 5)")
+    return conn
+
+
+@pytest.fixture
+def old_db_compound_pk(conn):
+    """Database with an old-style tracked table using compound PK."""
+    conn.execute(
+        "create table user_roles ("
+        "user_id integer, role_id integer, granted_by text, "
+        "primary key (user_id, role_id))"
+    )
+    _create_old_style_tracking(conn, "user_roles")
+    conn.execute(
+        "insert into user_roles (user_id, role_id, granted_by) "
+        "values (1, 10, 'admin')"
+    )
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Tests: detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectUpgrades:
+    def test_detects_missing_group_column(self, old_db):
+        actions = detect_upgrades(old_db)
+        assert len(actions) == 1
+        assert actions[0]["audit_table"] == "_history_json_items"
+        assert actions[0]["source_table"] == "items"
+        assert actions[0]["needs_column"] is True
+        assert actions[0]["source_exists"] is True
+
+    def test_detects_old_triggers(self, old_db):
+        actions = detect_upgrades(old_db)
+        assert actions[0]["needs_triggers"] is True
+
+    def test_nothing_to_upgrade_on_current_schema(self, conn):
+        """A database created with the current code needs no upgrades."""
+        conn.execute(
+            "create table items ("
+            "id integer primary key, name text, price float)"
+        )
+        enable_tracking(conn, "items")
+        actions = detect_upgrades(conn)
+        assert actions == []
+
+    def test_detects_multiple_tables(self, old_db_multi):
+        actions = detect_upgrades(old_db_multi)
+        audit_names = {a["audit_table"] for a in actions}
+        assert audit_names == {"_history_json_items", "_history_json_orders"}
+        assert all(a["needs_column"] for a in actions)
+        assert all(a["needs_triggers"] for a in actions)
+
+    def test_empty_database_nothing_to_upgrade(self, conn):
+        actions = detect_upgrades(conn)
+        assert actions == []
+
+    def test_detects_compound_pk_table(self, old_db_compound_pk):
+        actions = detect_upgrades(old_db_compound_pk)
+        assert len(actions) == 1
+        assert actions[0]["audit_table"] == "_history_json_user_roles"
+
+    def test_source_table_gone(self, conn):
+        """If the source table was dropped, still detect column issue."""
+        conn.execute(
+            "create table items (id integer primary key, name text)"
+        )
+        _create_old_style_tracking(conn, "items")
+        conn.execute("drop trigger [_history_json_items_insert]")
+        conn.execute("drop trigger [_history_json_items_update]")
+        conn.execute("drop trigger [_history_json_items_delete]")
+        conn.execute("drop table items")
+        actions = detect_upgrades(conn)
+        assert len(actions) == 1
+        assert actions[0]["needs_column"] is True
+        assert actions[0]["source_exists"] is False
+        # Can't upgrade triggers without the source table
+        assert actions[0]["needs_triggers"] is False
+
+    def test_column_present_but_triggers_old(self, conn):
+        """If column was manually added but triggers are old-style."""
+        conn.execute(
+            "create table items (id integer primary key, name text)"
+        )
+        _create_old_style_tracking(conn, "items")
+        # Manually add the column
+        conn.execute(
+            "alter table [_history_json_items] "
+            "add column [group] integer references [_history_json](id)"
+        )
+        actions = detect_upgrades(conn)
+        assert len(actions) == 1
+        assert actions[0]["needs_column"] is False
+        assert actions[0]["needs_triggers"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: apply_upgrade
+# ---------------------------------------------------------------------------
+
+
+class TestApplyUpgrade:
+    def test_adds_group_column(self, old_db):
+        assert not _has_column(old_db, "_history_json_items", "group")
+        apply_upgrade(old_db)
+        assert _has_column(old_db, "_history_json_items", "group")
+
+    def test_creates_groups_table(self, old_db):
+        """The shared _history_json table should be created."""
+        apply_upgrade(old_db)
+        exists = old_db.execute(
+            "select count(*) from sqlite_master "
+            "where type = 'table' and name = '_history_json'"
+        ).fetchone()[0]
+        assert exists == 1
+
+    def test_existing_rows_have_null_group(self, old_db):
+        """Pre-existing audit rows should have group = NULL."""
+        apply_upgrade(old_db)
+        rows = old_db.execute(
+            "select [group] from [_history_json_items]"
+        ).fetchall()
+        assert all(r[0] is None for r in rows)
+
+    def test_preserves_existing_history(self, old_db):
+        """Upgrade should not lose any existing audit data."""
+        before = old_db.execute(
+            "select id, timestamp, operation, pk_id, updated_values "
+            "from [_history_json_items] order by id"
+        ).fetchall()
+        apply_upgrade(old_db)
+        after = old_db.execute(
+            "select id, timestamp, operation, pk_id, updated_values "
+            "from [_history_json_items] order by id"
+        ).fetchall()
+        assert before == after
+
+    def test_triggers_recreated(self, old_db):
+        """After upgrade, triggers should include the [group] subquery."""
+        apply_upgrade(old_db)
+        assert not _trigger_needs_upgrade(old_db, "_history_json_items")
+
+    def test_new_inserts_work_after_upgrade(self, old_db):
+        """INSERTs after upgrade should succeed and have group = NULL."""
+        apply_upgrade(old_db)
+        old_db.execute(
+            "insert into items (id, name, price, quantity) "
+            "values (2, 'Gadget', 5.99, 50)"
+        )
+        row = old_db.execute(
+            "select [group] from [_history_json_items] order by id desc limit 1"
+        ).fetchone()
+        assert row[0] is None
+
+    def test_new_updates_work_after_upgrade(self, old_db):
+        apply_upgrade(old_db)
+        old_db.execute("update items set name = 'SuperWidget' where id = 1")
+        row = old_db.execute(
+            "select operation, [group] from [_history_json_items] "
+            "order by id desc limit 1"
+        ).fetchone()
+        assert row[0] == "update"
+        assert row[1] is None
+
+    def test_new_deletes_work_after_upgrade(self, old_db):
+        apply_upgrade(old_db)
+        old_db.execute("delete from items where id = 1")
+        row = old_db.execute(
+            "select operation, [group] from [_history_json_items] "
+            "order by id desc limit 1"
+        ).fetchone()
+        assert row[0] == "delete"
+        assert row[1] is None
+
+    def test_change_group_works_after_upgrade(self, old_db):
+        """After upgrade, change_group() should correctly tag new entries."""
+        apply_upgrade(old_db)
+        with change_group(old_db, note="post-upgrade batch") as gid:
+            old_db.execute(
+                "insert into items (id, name, price, quantity) "
+                "values (3, 'Thingamajig', 1.99, 300)"
+            )
+            old_db.execute("update items set price = 15.99 where id = 1")
+        rows = old_db.execute(
+            "select [group] from [_history_json_items] "
+            "where [group] is not null"
+        ).fetchall()
+        assert len(rows) == 2
+        assert all(r[0] == gid for r in rows)
+
+    def test_get_history_works_after_upgrade(self, old_db):
+        """get_history() should work correctly on upgraded databases."""
+        apply_upgrade(old_db)
+        entries = get_history(old_db, "items")
+        assert len(entries) == 2
+        assert entries[0]["group"] is None
+        assert entries[0]["group_note"] is None
+
+    def test_get_row_history_works_after_upgrade(self, old_db):
+        apply_upgrade(old_db)
+        entries = get_row_history(old_db, "items", {"id": 1})
+        assert len(entries) == 2
+        for e in entries:
+            assert "group" in e
+            assert "group_note" in e
+
+    def test_upgrades_multiple_tables(self, old_db_multi):
+        actions = apply_upgrade(old_db_multi)
+        assert len(actions) == 2
+        for table in ("_history_json_items", "_history_json_orders"):
+            assert _has_column(old_db_multi, table, "group")
+
+    def test_upgrades_compound_pk(self, old_db_compound_pk):
+        apply_upgrade(old_db_compound_pk)
+        assert _has_column(
+            old_db_compound_pk, "_history_json_user_roles", "group"
+        )
+        # Verify triggers work
+        old_db_compound_pk.execute(
+            "insert into user_roles (user_id, role_id, granted_by) "
+            "values (2, 20, 'admin')"
+        )
+        row = old_db_compound_pk.execute(
+            "select [group] from [_history_json_user_roles] "
+            "order by id desc limit 1"
+        ).fetchone()
+        assert row[0] is None
+
+    def test_idempotent(self, old_db):
+        """Running upgrade twice should be safe."""
+        actions1 = apply_upgrade(old_db)
+        assert len(actions1) == 1
+        actions2 = apply_upgrade(old_db)
+        assert actions2 == []
+
+    def test_returns_empty_for_current_schema(self, conn):
+        conn.execute(
+            "create table items (id integer primary key, name text)"
+        )
+        enable_tracking(conn, "items")
+        actions = apply_upgrade(conn)
+        assert actions == []
+
+    def test_mixed_old_and_new_tables(self, conn):
+        """Database with one old and one new tracked table."""
+        conn.execute(
+            "create table items (id integer primary key, name text)"
+        )
+        conn.execute(
+            "create table orders (id integer primary key, item_id integer)"
+        )
+        # items: old-style
+        _create_old_style_tracking(conn, "items")
+        # orders: current-style
+        enable_tracking(conn, "orders")
+
+        actions = apply_upgrade(conn)
+        assert len(actions) == 1
+        assert actions[0]["audit_table"] == "_history_json_items"
+
+    def test_upgrade_with_existing_data_and_new_change_group(self, old_db):
+        """Full round-trip: old data, upgrade, new grouped changes, query all."""
+        apply_upgrade(old_db)
+
+        # Add new grouped changes
+        with change_group(old_db, note="batch") as gid:
+            old_db.execute(
+                "insert into items (id, name, price, quantity) "
+                "values (2, 'Gadget', 5.99, 50)"
+            )
+
+        entries = get_history(old_db, "items")
+        # Should have 3 entries: 2 old (null group) + 1 new (with group)
+        assert len(entries) == 3
+        grouped = [e for e in entries if e["group"] is not None]
+        ungrouped = [e for e in entries if e["group"] is None]
+        assert len(grouped) == 1
+        assert grouped[0]["group"] == gid
+        assert grouped[0]["group_note"] == "batch"
+        assert len(ungrouped) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLI (main function)
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def _make_old_db_file(self):
+        """Create a temp file with an old-style tracked database."""
+        f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        conn = sqlite3.connect(f.name)
+        conn.execute(
+            "create table items ("
+            "id integer primary key, name text, price float)"
+        )
+        _create_old_style_tracking(conn, "items")
+        conn.execute(
+            "insert into items (id, name, price) values (1, 'Widget', 9.99)"
+        )
+        conn.commit()
+        conn.close()
+        return f.name
+
+    def test_dry_run_reports_actions(self, capsys):
+        db_path = self._make_old_db_file()
+        main(["--dry-run", db_path])
+        captured = capsys.readouterr()
+        assert "Would upgrade _history_json_items" in captured.err
+        assert "add [group] column" in captured.err
+        assert "recreate triggers" in captured.err
+
+        # Verify nothing was actually changed
+        conn = sqlite3.connect(db_path)
+        assert not _has_column(conn, "_history_json_items", "group")
+        conn.close()
+
+    def test_dry_run_nothing_to_do(self, capsys):
+        f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        conn = sqlite3.connect(f.name)
+        conn.execute(
+            "create table items (id integer primary key, name text)"
+        )
+        enable_tracking(conn, "items")
+        conn.commit()
+        conn.close()
+
+        main(["--dry-run", f.name])
+        captured = capsys.readouterr()
+        assert "Nothing to upgrade" in captured.err
+
+    def test_actual_upgrade(self, capsys):
+        db_path = self._make_old_db_file()
+        main([db_path])
+        captured = capsys.readouterr()
+        assert "Upgraded _history_json_items" in captured.err
+        assert "added [group] column" in captured.err
+        assert "recreated triggers" in captured.err
+
+        # Verify the upgrade was applied
+        conn = sqlite3.connect(db_path)
+        assert _has_column(conn, "_history_json_items", "group")
+        conn.close()
+
+    def test_nothing_to_upgrade(self, capsys):
+        f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        conn = sqlite3.connect(f.name)
+        conn.execute(
+            "create table items (id integer primary key, name text)"
+        )
+        enable_tracking(conn, "items")
+        conn.commit()
+        conn.close()
+
+        main([f.name])
+        captured = capsys.readouterr()
+        assert "Nothing to upgrade" in captured.err
+
+    def test_runnable_as_module(self):
+        """python -m sqlite_history_json.upgrade --help should work."""
+        result = subprocess.run(
+            [sys.executable, "-m", "sqlite_history_json.upgrade", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "--dry-run" in result.stdout
+
+    def test_dry_run_flag_before_database(self, capsys):
+        """--dry-run can come before the database argument."""
+        db_path = self._make_old_db_file()
+        main(["--dry-run", db_path])
+        captured = capsys.readouterr()
+        assert "Would upgrade" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Tests: _find_audit_tables helper
+# ---------------------------------------------------------------------------
+
+
+class TestFindAuditTables:
+    def test_finds_audit_tables(self, old_db_multi):
+        tables = _find_audit_tables(old_db_multi)
+        assert set(tables) == {"_history_json_items", "_history_json_orders"}
+
+    def test_does_not_include_groups_table(self, conn):
+        """The _history_json groups table should not be returned."""
+        conn.execute(
+            "create table items (id integer primary key, name text)"
+        )
+        enable_tracking(conn, "items")
+        tables = _find_audit_tables(conn)
+        assert "_history_json" not in tables
+        assert "_history_json_items" in tables
+
+    def test_empty_database(self, conn):
+        assert _find_audit_tables(conn) == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_audit_table_with_no_source_table(self, conn):
+        """An orphaned audit table (source dropped) should still get the column."""
+        conn.execute(
+            "create table items (id integer primary key, name text)"
+        )
+        _create_old_style_tracking(conn, "items")
+        conn.execute(
+            "insert into items (id, name) values (1, 'Widget')"
+        )
+        # Drop source table (and its triggers)
+        conn.execute("drop table items")
+
+        actions = apply_upgrade(conn)
+        assert len(actions) == 1
+        assert actions[0]["needs_column"] is True
+        # Triggers can't be recreated without source table
+        assert actions[0]["needs_triggers"] is False
+        # But column was added
+        assert _has_column(conn, "_history_json_items", "group")
+
+    def test_enable_tracking_on_upgraded_table(self, old_db):
+        """After upgrade, calling enable_tracking again should be harmless."""
+        apply_upgrade(old_db)
+        # disable then re-enable
+        from sqlite_history_json import disable_tracking
+
+        disable_tracking(old_db, "items")
+        enable_tracking(old_db, "items", populate_table=False)
+        # Should still work
+        old_db.execute(
+            "insert into items (id, name, price, quantity) "
+            "values (5, 'NewItem', 2.99, 10)"
+        )
+        entries = get_history(old_db, "items")
+        assert entries[0]["operation"] == "insert"
+        assert entries[0]["group"] is None


### PR DESCRIPTION
Databases created before change-grouping support was added are missing
the [group] column on audit tables and the _history_json groups table.
This adds a `python -m sqlite_history_json.upgrade database.db` command
that detects and applies the necessary schema changes (with --dry-run
support). It adds the groups table, the [group] FK column, and recreates
triggers to populate it.

https://claude.ai/code/session_01QuKekf3igCVVD8KqVK5yMK