### PR TITLE
Skip no-op UPDATE audit entries using WHEN clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,34 +29,121 @@ The audit log is self-contained: given only the audit table, you can fully recon
 | `NULL` | `{"null": 1}` (because `json_patch()` treats bare `null` as "remove key") |
 | BLOB | `{"hex": "DEADBEEF"}` (hex-encoded binary) |
 
-### Audit table schema
+### Example SQL schema
 
-For a table called `items` with primary key `id`, the audit table `_history_json_items` looks like:
+For a table called `items` with columns `id`, `name`, `price`, and `quantity`, calling `enable_tracking()` creates the following schema:
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | INTEGER PRIMARY KEY | Auto-incrementing version number |
-| `timestamp` | TEXT | ISO-8601 datetime with microsecond precision |
-| `operation` | TEXT | `'insert'`, `'update'`, or `'delete'` |
-| `pk_id` | (matches source PK type) | The primary key of the tracked row (prefixed with `pk_`) |
-| `updated_values` | TEXT | JSON object of changed columns (NULL for deletes) |
-| `group` | INTEGER | Foreign key to `_history_json.id` (NULL when no group is active) |
+<!-- [[[cog
+import cog
+import sqlite3
+import sqlite_history_json
+db = sqlite3.connect(":memory:")
+db.execute("create table items (id integer primary key, name text, price float, quantity integer)")
+sqlite_history_json.enable_tracking(db, "items", populate_table=False)
+cog.out("```sql\n")
+cog.outl(";\n\n".join(r[0] for r in db.execute("select sql from sqlite_master").fetchall() if r[0]))
+cog.out("\n```")
+]]] -->
+```sql
+CREATE TABLE items (id integer primary key, name text, price float, quantity integer);
+
+CREATE TABLE [_history_json] (
+    id integer primary key,
+    note text,
+    current integer
+);
+
+CREATE UNIQUE INDEX [_history_json_current] on [_history_json] (current) where current = 1;
+
+CREATE TABLE [_history_json_items] (
+    id integer primary key,
+    timestamp text,
+    operation text,
+    [pk_id] INTEGER,
+    updated_values text,
+    [group] integer references [_history_json](id)
+);
+
+CREATE TRIGGER [history_json_v2_insert_items]
+after insert on [items]
+begin
+    insert into [_history_json_items] (timestamp, operation, [pk_id], updated_values, [group])
+    values (
+        strftime('%Y-%m-%d %H:%M:%f', 'now'),
+        'insert',
+        NEW.[id],
+        json_object('name', case when NEW.[name] is null then json_object('null', 1) else NEW.[name] end, 'price', case when NEW.[price] is null then json_object('null', 1) else NEW.[price] end, 'quantity', case when NEW.[quantity] is null then json_object('null', 1) else NEW.[quantity] end),
+        (select id from [_history_json] where current = 1)
+    );
+end;
+
+CREATE TRIGGER [history_json_v2_update_items]
+after update on [items]
+when OLD.[name] is not NEW.[name] or OLD.[price] is not NEW.[price] or OLD.[quantity] is not NEW.[quantity]
+begin
+    insert into [_history_json_items] (timestamp, operation, [pk_id], updated_values, [group])
+    values (
+        strftime('%Y-%m-%d %H:%M:%f', 'now'),
+        'update',
+        NEW.[id],
+        json_patch(
+            json_patch(
+            json_patch(
+            '{}',
+            case
+                when OLD.[name] is not NEW.[name] then
+                    case
+                        when NEW.[name] is null then json_object('name', json_object('null', 1))
+                        else json_object('name', NEW.[name])
+                    end
+                else '{}'
+            end
+        ),
+            case
+                when OLD.[price] is not NEW.[price] then
+                    case
+                        when NEW.[price] is null then json_object('price', json_object('null', 1))
+                        else json_object('price', NEW.[price])
+                    end
+                else '{}'
+            end
+        ),
+            case
+                when OLD.[quantity] is not NEW.[quantity] then
+                    case
+                        when NEW.[quantity] is null then json_object('quantity', json_object('null', 1))
+                        else json_object('quantity', NEW.[quantity])
+                    end
+                else '{}'
+            end
+        ),
+        (select id from [_history_json] where current = 1)
+    );
+end;
+
+CREATE TRIGGER [history_json_v2_delete_items]
+after delete on [items]
+begin
+    insert into [_history_json_items] (timestamp, operation, [pk_id], updated_values, [group])
+    values (
+        strftime('%Y-%m-%d %H:%M:%f', 'now'),
+        'delete',
+        OLD.[id],
+        null,
+        (select id from [_history_json] where current = 1)
+    );
+end;
+
+CREATE INDEX [_history_json_items_timestamp] on [_history_json_items] (timestamp);
+
+CREATE INDEX [_history_json_items_pk] on [_history_json_items] ([pk_id])
+
+```
+<!-- [[[end]]] -->
 
 Primary key columns in the audit table are always prefixed with `pk_` to distinguish them from the audit table's own columns. For compound primary keys, each PK column gets its own `pk_`-prefixed column (e.g., `pk_user_id`, `pk_role_id`).
 
-Indexes are automatically created on `timestamp` and the PK column(s) for efficient querying.
-
-### Change groups table
-
-A shared `_history_json` table (no suffix) is created when tracking is first enabled. It stores change-group metadata:
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | INTEGER PRIMARY KEY | Auto-incrementing group identifier |
-| `note` | TEXT | Optional description of the batch of changes |
-| `current` | INTEGER | Set to `1` during an active `change_group()` block, otherwise NULL |
-
-The `current` column is indexed. During a `change_group()` context, triggers use `(SELECT id FROM _history_json WHERE current = 1)` to look up the active group. When no group is active, this returns NULL and audit rows are written with `group = NULL`.
+The `_history_json` table (no suffix) stores change-group metadata. During a `change_group()` context, triggers use `(SELECT id FROM _history_json WHERE current = 1)` to look up the active group. When no group is active, this returns NULL and audit rows are written with `group = NULL`.
 
 ## Installation
 
@@ -542,48 +629,10 @@ uv run python -m sqlite_history_json --help
 
 ## How the triggers work
 
-The UPDATE trigger uses a `WHEN` clause to skip no-op updates entirely — if no non-PK column actually changed, the trigger does not fire and no audit entry is created. This uses SQLite's `IS NOT` operator which correctly treats NULL-to-NULL as "no change":
+The trigger SQL is shown in the [schema above](#example-sql-schema). Key details:
 
-```sql
-CREATE TRIGGER [history_json_v2_update_items]
-AFTER UPDATE ON [items]
-WHEN OLD.[name] IS NOT NEW.[name]
-  OR OLD.[price] IS NOT NEW.[price]
-  OR OLD.[quantity] IS NOT NEW.[quantity]
-BEGIN
-  INSERT INTO _history_json_items (timestamp, operation, pk_id, updated_values, [group])
-  VALUES (
-    strftime('%Y-%m-%d %H:%M:%f', 'now'),
-    'update',
-    NEW.id,
-    json_patch(
-      json_patch(
-        json_patch('{}',
-          CASE WHEN OLD.name IS NOT NEW.name THEN
-            CASE WHEN NEW.name IS NULL THEN json_object('name', json_object('null', 1))
-                 ELSE json_object('name', NEW.name) END
-          ELSE '{}' END
-        ),
-        CASE WHEN OLD.price IS NOT NEW.price THEN
-          CASE WHEN NEW.price IS NULL THEN json_object('price', json_object('null', 1))
-               ELSE json_object('price', NEW.price) END
-        ELSE '{}' END
-      ),
-      CASE WHEN OLD.quantity IS NOT NEW.quantity THEN
-        CASE WHEN NEW.quantity IS NULL THEN json_object('quantity', json_object('null', 1))
-             ELSE json_object('quantity', NEW.quantity) END
-      ELSE '{}' END
-    ),
-    (SELECT id FROM _history_json WHERE current = 1)
-  );
-END;
-```
-
-The `WHEN` clause checks each non-PK column for changes using `IS NOT`. Inside the trigger body, each column gets a `CASE` expression that:
-1. Checks if the old and new values differ
-2. If different, creates a JSON object with the column name and new value
-3. If unchanged, returns `'{}'` (empty object)
-
-These are combined with `json_patch()` which merges JSON objects together, building up the final diff.
-
-The group subquery `(SELECT id FROM _history_json WHERE current = 1)` is the same in all three triggers (INSERT, UPDATE, DELETE). It returns the active group's id when called inside a `change_group()` context, or NULL otherwise.
+- The **INSERT** trigger records all non-PK column values as a JSON object using `json_object()`.
+- The **UPDATE** trigger uses a `WHEN` clause to skip no-op updates entirely — if no non-PK column actually changed (checked via `IS NOT`, which handles NULL correctly), the trigger does not fire. Inside the body, nested `json_patch()` calls build a JSON object containing only the columns that differ.
+- The **DELETE** trigger records `NULL` for `updated_values`.
+- All three triggers populate the `[group]` column via `(SELECT id FROM _history_json WHERE current = 1)`, which returns the active change group id or NULL.
+- Trigger names include a version number (e.g., `history_json_v2_update_items`) so the [upgrade module](#upgrading-older-databases) can detect outdated triggers by name.

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ The output is a ready-to-execute SQL query using a recursive CTE and `json_patch
 
 Databases created with older versions may need schema upgrades. The upgrade script detects and applies necessary changes automatically. It handles both pre-group databases (missing `[group]` column) and databases with unversioned trigger names.
 
-Trigger names include a version number (e.g., `_history_json_v2_update_items`) so the upgrade script can detect outdated triggers by name rather than inspecting SQL bodies. When the trigger format changes in a future release, incrementing the version number is all that's needed.
+Trigger names include a version number (e.g., `history_json_v2_update_items`) so the upgrade script can detect outdated triggers by name rather than inspecting SQL bodies. When the trigger format changes in a future release, incrementing the version number is all that's needed.
 
 Preview what would be changed:
 
@@ -545,7 +545,7 @@ uv run python -m sqlite_history_json --help
 The UPDATE trigger uses a `WHEN` clause to skip no-op updates entirely — if no non-PK column actually changed, the trigger does not fire and no audit entry is created. This uses SQLite's `IS NOT` operator which correctly treats NULL-to-NULL as "no change":
 
 ```sql
-CREATE TRIGGER [_history_json_v2_update_items]
+CREATE TRIGGER [history_json_v2_update_items]
 AFTER UPDATE ON [items]
 WHEN OLD.[name] IS NOT NEW.[name]
   OR OLD.[price] IS NOT NEW.[price]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "pytest"
+    "cogapp>=3.6.0",
+    "pytest",
 ]
 
 [tool.setuptools]

--- a/sqlite_history_json/core.py
+++ b/sqlite_history_json/core.py
@@ -88,7 +88,7 @@ def _audit_table_name(table_name: str) -> str:
 
 def _trigger_name(table_name: str, operation: str) -> str:
     """Return the versioned trigger name for a given table and operation."""
-    return f"_history_json_v{_TRIGGER_VERSION}_{operation}_{table_name}"
+    return f"history_json_v{_TRIGGER_VERSION}_{operation}_{table_name}"
 
 
 def _audit_pk_col_name(source_col_name: str) -> str:

--- a/sqlite_history_json/upgrade.py
+++ b/sqlite_history_json/upgrade.py
@@ -5,12 +5,14 @@ Run as::
     python -m sqlite_history_json.upgrade database.db
     python -m sqlite_history_json.upgrade database.db --dry-run
 
-The upgrade detects audit tables created before change-grouping support
-was added and:
+The upgrade detects audit tables that need changes and:
 
 1. Creates the ``_history_json`` groups table (if it does not exist).
 2. Adds a ``[group]`` column to each audit table that is missing it.
-3. Drops and recreates triggers so they populate the new column.
+3. Drops and recreates triggers with current versioned names.
+
+Trigger names include a version number (e.g. ``_history_json_v2_insert_items``)
+so detection is based on name matching rather than SQL body inspection.
 """
 
 from __future__ import annotations
@@ -29,6 +31,8 @@ from .core import (
     _get_pk_columns,
     _get_table_info,
     _GROUPS_TABLE,
+    _trigger_name,
+    _TRIGGER_VERSION,
 )
 
 
@@ -64,20 +68,26 @@ def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
     )
 
 
-def _trigger_sql(conn: sqlite3.Connection, trigger_name: str) -> str | None:
-    """Return the SQL body of an existing trigger, or None."""
-    row = conn.execute(
-        "select sql from sqlite_master where type = 'trigger' and name = ?",
-        (trigger_name,),
-    ).fetchone()
-    return row[0] if row else None
+def _trigger_exists(conn: sqlite3.Connection, name: str) -> bool:
+    """Return True if a trigger with this exact name exists."""
+    return (
+        conn.execute(
+            "select count(*) from sqlite_master where type = 'trigger' and name = ?",
+            (name,),
+        ).fetchone()[0]
+        > 0
+    )
 
 
 def _trigger_needs_upgrade(conn: sqlite3.Connection, audit_name: str) -> bool:
-    """Return True if any trigger for *audit_name* is missing the group subquery."""
-    for suffix in ("_insert", "_update", "_delete"):
-        sql = _trigger_sql(conn, f"{audit_name}{suffix}")
-        if sql is not None and "[group]" not in sql:
+    """Return True if the triggers for *audit_name* are not at the current version.
+
+    Checks whether the current versioned trigger names exist. If any are
+    missing, the triggers need to be (re)created.
+    """
+    source_table = _source_table_for(audit_name)
+    for op in ("insert", "update", "delete"):
+        if not _trigger_exists(conn, _trigger_name(source_table, op)):
             return True
     return False
 
@@ -148,13 +158,17 @@ def apply_upgrade(conn: sqlite3.Connection) -> list[dict]:
             pk_cols = _get_pk_columns(columns)
             non_pk_cols = _get_non_pk_columns(columns)
 
-            # Drop old triggers
-            for suffix in ("_insert", "_update", "_delete"):
-                conn.execute(
-                    f"drop trigger if exists [{audit_name}{suffix}]"
-                )
+            # Drop ALL existing triggers on this source table that belong to us
+            existing = conn.execute(
+                "select name from sqlite_master "
+                "where type = 'trigger' and tbl_name = ?",
+                (source_table,),
+            ).fetchall()
+            for (trig_name,) in existing:
+                if trig_name.startswith("_history_json"):
+                    conn.execute(f"drop trigger if exists [{trig_name}]")
 
-            # Create new triggers (with [group] subquery)
+            # Create new versioned triggers
             conn.execute(
                 _build_insert_trigger_sql(
                     source_table, audit_name, pk_cols, non_pk_cols

--- a/sqlite_history_json/upgrade.py
+++ b/sqlite_history_json/upgrade.py
@@ -11,7 +11,7 @@ The upgrade detects audit tables that need changes and:
 2. Adds a ``[group]`` column to each audit table that is missing it.
 3. Drops and recreates triggers with current versioned names.
 
-Trigger names include a version number (e.g. ``_history_json_v2_insert_items``)
+Trigger names include a version number (e.g. ``history_json_v2_insert_items``)
 so detection is based on name matching rather than SQL body inspection.
 """
 
@@ -165,7 +165,7 @@ def apply_upgrade(conn: sqlite3.Connection) -> list[dict]:
                 (source_table,),
             ).fetchall()
             for (trig_name,) in existing:
-                if trig_name.startswith("_history_json"):
+                if trig_name.startswith(("_history_json", "history_json_v")):
                     conn.execute(f"drop trigger if exists [{trig_name}]")
 
             # Create new versioned triggers

--- a/tests/test_sqlite_history_json.py
+++ b/tests/test_sqlite_history_json.py
@@ -193,9 +193,9 @@ class TestEnableTracking:
         enable_tracking(simple_table, "items")
         triggers = trigger_names(simple_table, "items")
         expected = sorted([
-            f"_history_json_v{_TRIGGER_VERSION}_insert_items",
-            f"_history_json_v{_TRIGGER_VERSION}_update_items",
-            f"_history_json_v{_TRIGGER_VERSION}_delete_items",
+            f"history_json_v{_TRIGGER_VERSION}_insert_items",
+            f"history_json_v{_TRIGGER_VERSION}_update_items",
+            f"history_json_v{_TRIGGER_VERSION}_delete_items",
         ])
         assert triggers == expected
 
@@ -206,9 +206,9 @@ class TestEnableTracking:
         enable_tracking(compound_pk_table, "user_roles")
         triggers = trigger_names(compound_pk_table, "user_roles")
         expected = sorted([
-            f"_history_json_v{_TRIGGER_VERSION}_insert_user_roles",
-            f"_history_json_v{_TRIGGER_VERSION}_update_user_roles",
-            f"_history_json_v{_TRIGGER_VERSION}_delete_user_roles",
+            f"history_json_v{_TRIGGER_VERSION}_insert_user_roles",
+            f"history_json_v{_TRIGGER_VERSION}_update_user_roles",
+            f"history_json_v{_TRIGGER_VERSION}_delete_user_roles",
         ])
         assert triggers == expected
 
@@ -222,9 +222,9 @@ class TestEnableTracking:
         enable_tracking(conn, "my-table")
         triggers = trigger_names(conn, "my-table")
         expected = sorted([
-            f"_history_json_v{_TRIGGER_VERSION}_insert_my-table",
-            f"_history_json_v{_TRIGGER_VERSION}_update_my-table",
-            f"_history_json_v{_TRIGGER_VERSION}_delete_my-table",
+            f"history_json_v{_TRIGGER_VERSION}_insert_my-table",
+            f"history_json_v{_TRIGGER_VERSION}_update_my-table",
+            f"history_json_v{_TRIGGER_VERSION}_delete_my-table",
         ])
         assert triggers == expected
 

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -13,6 +13,7 @@ from sqlite_history_json import (
     get_history,
     get_row_history,
 )
+from sqlite_history_json.core import _TRIGGER_VERSION
 from sqlite_history_json.upgrade import (
     _find_audit_tables,
     _has_column,
@@ -120,6 +121,115 @@ end;"""
     )
 
 
+def _create_v1_style_tracking(conn: sqlite3.Connection, table_name: str) -> None:
+    """Set up audit table and triggers with group column but old (unversioned) names.
+
+    This simulates a database created after change-grouping was added but before
+    trigger names were versioned. Triggers are named ``_history_json_{table}_{op}``
+    (the old convention) but include the [group] column.
+    """
+    columns = conn.execute(f"pragma table_info([{table_name}])").fetchall()
+    pk_cols = sorted(
+        [c for c in columns if c[5] > 0], key=lambda c: c[5]
+    )
+    non_pk_cols = [c for c in columns if c[5] == 0]
+
+    audit_name = f"_history_json_{table_name}"
+
+    pk_col_defs = ", ".join(f"[pk_{c[1]}] {c[2]}" for c in pk_cols)
+
+    # Create the groups table
+    conn.execute(
+        """create table if not exists [_history_json] (
+    id integer primary key,
+    note text,
+    current integer
+)"""
+    )
+    conn.execute(
+        "create unique index if not exists [_history_json_current] "
+        "on [_history_json] (current) where current = 1"
+    )
+
+    # Audit table WITH [group] column (v1 schema)
+    conn.execute(
+        f"""create table [{audit_name}] (
+    id integer primary key,
+    timestamp text,
+    operation text,
+    {pk_col_defs},
+    updated_values text,
+    [group] integer references [_history_json](id)
+)"""
+    )
+
+    # v1-style triggers: include [group] but use old naming convention
+    audit_pk_names = ", ".join(f"[pk_{c[1]}]" for c in pk_cols)
+    pk_new_refs = ", ".join(f"NEW.[{c[1]}]" for c in pk_cols)
+    group_sub = "(select id from [_history_json] where current = 1)"
+    json_args = ", ".join(
+        f"'{c[1]}', case when NEW.[{c[1]}] is null "
+        f"then json_object('null', 1) else NEW.[{c[1]}] end"
+        for c in non_pk_cols
+    )
+    json_obj = f"json_object({json_args})" if json_args else "'{{}}'"
+
+    # Old naming: {audit_name}_{operation}
+    conn.execute(
+        f"""create trigger [{audit_name}_insert]
+after insert on [{table_name}]
+begin
+    insert into [{audit_name}] (timestamp, operation, {audit_pk_names}, updated_values, [group])
+    values (
+        strftime('%Y-%m-%d %H:%M:%f', 'now'),
+        'insert',
+        {pk_new_refs},
+        {json_obj},
+        {group_sub}
+    );
+end;"""
+    )
+
+    conn.execute(
+        f"""create trigger [{audit_name}_update]
+after update on [{table_name}]
+begin
+    insert into [{audit_name}] (timestamp, operation, {audit_pk_names}, updated_values, [group])
+    values (
+        strftime('%Y-%m-%d %H:%M:%f', 'now'),
+        'update',
+        {pk_new_refs},
+        {json_obj},
+        {group_sub}
+    );
+end;"""
+    )
+
+    pk_old_refs = ", ".join(f"OLD.[{c[1]}]" for c in pk_cols)
+    conn.execute(
+        f"""create trigger [{audit_name}_delete]
+after delete on [{table_name}]
+begin
+    insert into [{audit_name}] (timestamp, operation, {audit_pk_names}, updated_values, [group])
+    values (
+        strftime('%Y-%m-%d %H:%M:%f', 'now'),
+        'delete',
+        {pk_old_refs},
+        null,
+        {group_sub}
+    );
+end;"""
+    )
+
+    conn.execute(
+        f"create index [{audit_name}_timestamp] on [{audit_name}] (timestamp)"
+    )
+    audit_pk_col_names = ", ".join(f"[pk_{c[1]}]" for c in pk_cols)
+    conn.execute(
+        f"create index [{audit_name}_pk] on [{audit_name}] ({audit_pk_col_names})"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -164,6 +274,21 @@ def old_db_multi(conn):
     _create_old_style_tracking(conn, "orders")
     conn.execute("insert into items (id, name, price) values (1, 'Widget', 9.99)")
     conn.execute("insert into orders (id, item_id, qty) values (1, 1, 5)")
+    return conn
+
+
+@pytest.fixture
+def v1_db(conn):
+    """Database with v1-style tracked table (has group column, unversioned triggers)."""
+    conn.execute(
+        "create table items ("
+        "id integer primary key, name text, price float, quantity integer)"
+    )
+    _create_v1_style_tracking(conn, "items")
+    conn.execute(
+        "insert into items (id, name, price, quantity) values (1, 'Widget', 9.99, 100)"
+    )
+    conn.execute("update items set price = 12.99 where id = 1")
     return conn
 
 
@@ -256,6 +381,13 @@ class TestDetectUpgrades:
             "add column [group] integer references [_history_json](id)"
         )
         actions = detect_upgrades(conn)
+        assert len(actions) == 1
+        assert actions[0]["needs_column"] is False
+        assert actions[0]["needs_triggers"] is True
+
+    def test_detects_v1_unversioned_triggers(self, v1_db):
+        """v1-style triggers (with group, but unversioned names) need upgrade."""
+        actions = detect_upgrades(v1_db)
         assert len(actions) == 1
         assert actions[0]["needs_column"] is False
         assert actions[0]["needs_triggers"] is True
@@ -424,6 +556,61 @@ class TestApplyUpgrade:
         actions = apply_upgrade(conn)
         assert len(actions) == 1
         assert actions[0]["audit_table"] == "_history_json_items"
+
+    def test_upgrades_v1_triggers_to_versioned(self, v1_db):
+        """v1-style triggers should be replaced with versioned triggers."""
+        apply_upgrade(v1_db)
+        triggers = v1_db.execute(
+            "select name from sqlite_master where type='trigger' and tbl_name='items'"
+        ).fetchall()
+        trigger_names = sorted(r[0] for r in triggers)
+        expected = sorted([
+            f"_history_json_v{_TRIGGER_VERSION}_insert_items",
+            f"_history_json_v{_TRIGGER_VERSION}_update_items",
+            f"_history_json_v{_TRIGGER_VERSION}_delete_items",
+        ])
+        assert trigger_names == expected
+
+    def test_v1_upgrade_preserves_history(self, v1_db):
+        """Upgrading from v1 should preserve existing audit data."""
+        before = v1_db.execute(
+            "select id, timestamp, operation, pk_id, updated_values "
+            "from [_history_json_items] order by id"
+        ).fetchall()
+        apply_upgrade(v1_db)
+        after = v1_db.execute(
+            "select id, timestamp, operation, pk_id, updated_values "
+            "from [_history_json_items] order by id"
+        ).fetchall()
+        assert before == after
+
+    def test_v1_upgrade_old_triggers_removed(self, v1_db):
+        """Old unversioned trigger names should be gone after upgrade."""
+        apply_upgrade(v1_db)
+        old_trigger = v1_db.execute(
+            "select name from sqlite_master where type='trigger' "
+            "and name = '_history_json_items_update'"
+        ).fetchone()
+        assert old_trigger is None
+
+    def test_v1_upgrade_inserts_work(self, v1_db):
+        """INSERTs should work after upgrading from v1."""
+        apply_upgrade(v1_db)
+        v1_db.execute(
+            "insert into items (id, name, price, quantity) "
+            "values (2, 'Gadget', 5.99, 50)"
+        )
+        row = v1_db.execute(
+            "select [group] from [_history_json_items] order by id desc limit 1"
+        ).fetchone()
+        assert row[0] is None
+
+    def test_v1_upgrade_idempotent(self, v1_db):
+        """Upgrading v1 twice should be safe."""
+        actions1 = apply_upgrade(v1_db)
+        assert len(actions1) == 1
+        actions2 = apply_upgrade(v1_db)
+        assert actions2 == []
 
     def test_upgrade_with_existing_data_and_new_change_group(self, old_db):
         """Full round-trip: old data, upgrade, new grouped changes, query all."""

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -565,9 +565,9 @@ class TestApplyUpgrade:
         ).fetchall()
         trigger_names = sorted(r[0] for r in triggers)
         expected = sorted([
-            f"_history_json_v{_TRIGGER_VERSION}_insert_items",
-            f"_history_json_v{_TRIGGER_VERSION}_update_items",
-            f"_history_json_v{_TRIGGER_VERSION}_delete_items",
+            f"history_json_v{_TRIGGER_VERSION}_insert_items",
+            f"history_json_v{_TRIGGER_VERSION}_update_items",
+            f"history_json_v{_TRIGGER_VERSION}_delete_items",
         ])
         assert trigger_names == expected
 


### PR DESCRIPTION
The UPDATE trigger now has a WHEN clause that checks whether any
non-PK column actually changed (using IS NOT for NULL-safe comparison).
If nothing changed, the trigger does not fire and no audit entry is
created, matching sqlite-chronicle's behavior.

Previously, a no-op UPDATE recorded an entry with empty '{}' values.

https://claude.ai/code/session_01KTXYwEdVULnCoNKRZbCKDa